### PR TITLE
Update Enterprise pricing to custom quote model

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Pricing"
-description: "SecureTransmit pricing. Solo $5/mo, Pro $49/mo, Business $249/mo, Enterprise from $5k/mo. Self-serve. No free tier."
+description: "SecureTransmit pricing. Solo $5/mo, Pro $49/mo, Business $249/mo, Enterprise contact us. Self-serve. No free tier."
 ---
 
 <!-- Page Header -->
@@ -135,10 +135,9 @@ description: "SecureTransmit pricing. Solo $5/mo, Pro $49/mo, Business $249/mo, 
                         <h3 class="card-title mb-1">Enterprise</h3>
                         <p class="pricing-tagline">Custom retention, SCIM, dedicated support.</p>
                         <div class="pricing-amount">
-                            <span class="pricing-price">$5k+</span>
-                            <span class="pricing-period">/ month</span>
+                            <span class="pricing-price">Custom</span>
                         </div>
-                        <p class="pricing-annual">Annual, quoted</p>
+                        <p class="pricing-annual">Contact us for pricing</p>
                         <ul class="pricing-features">
                             <li>Unlimited workflows, custom volume</li>
                             <li>Fully custom retention (incl. delete-on-ack default)</li>
@@ -176,8 +175,8 @@ description: "SecureTransmit pricing. Solo $5/mo, Pro $49/mo, Business $249/mo, 
                         <p class="text-muted mb-0">SSO, geo-blocking, higher throughput, priority support. Plus full retention configurability.</p>
                     </div>
                     <div class="col-md-4">
-                        <h3 class="h4 mb-2">Enterprise starts at $5k/mo.</h3>
-                        <p class="text-muted mb-0">Custom retention, dedicated support, SCIM, audit log export. Founding rates available for design partners, contact us.</p>
+                        <h3 class="h4 mb-2">Enterprise is custom.</h3>
+                        <p class="text-muted mb-0">Custom retention, dedicated support, SCIM, audit log export. Contact us for pricing.</p>
                     </div>
                 </div>
             </div>
@@ -404,14 +403,6 @@ description: "SecureTransmit pricing. Solo $5/mo, Pro $49/mo, Business $249/mo, 
                         </h3>
                         <div id="faqAi" class="accordion-collapse collapse" data-bs-parent="#pricingFaq">
                             <div class="accordion-body">No. AI enrichment steps call your provider with your API key. Your provider, your account, your data policy, your bill for tokens. SecureTransmit doesn't resell AI or take a cut.</div>
-                        </div>
-                    </div>
-                    <div class="accordion-item">
-                        <h3 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqFounding">What's a "founding rate" for Enterprise?</button>
-                        </h3>
-                        <div id="faqFounding" class="accordion-collapse collapse" data-bs-parent="#pricingFaq">
-                            <div class="accordion-body">Our public Enterprise floor is $5k/mo. For a limited number of design partners willing to work closely with us, we negotiate a founding rate. That's a private conversation, <a href="{{ '/contact/' | relative_url }}">contact us</a> and tell us what you're building.</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Updated the Enterprise pricing tier to move away from a fixed starting price ($5k/mo) to a custom quote model, reflecting a shift toward direct sales conversations for enterprise customers.

## Key Changes
- **Pricing display**: Changed Enterprise price from "$5k+" to "Custom" with removal of the "/ month" period label
- **CTA text**: Updated "Annual, quoted" to "Contact us for pricing" to better guide users
- **Meta description**: Updated page description to reflect "Enterprise contact us" instead of "Enterprise from $5k/mo"
- **Summary section**: Changed "Enterprise starts at $5k/mo" to "Enterprise is custom" with updated description emphasizing custom features and pricing inquiry
- **FAQ removal**: Deleted the "What's a 'founding rate' for Enterprise?" FAQ item that explained the $5k/mo floor and founding rate discounts, as this is no longer relevant to the new pricing model

## Implementation Details
These changes simplify the Enterprise tier messaging by removing references to specific pricing anchors and founding rates, instead directing all enterprise inquiries through a direct contact flow. This aligns the website with a consultative sales approach for high-value customers.

https://claude.ai/code/session_01HK2dQxj9N9ZZSxTfmnbNfJ